### PR TITLE
Add @Robotic-Conspiracy/Mentors to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
-# Adding Codeowners to require reviews from another coder before pushing to main
-* @Robotic-Conspiracy/Coders
+# Adding Codeowners to require reviews from another coder or mentor on protected branches
+
+* @Robotic-Conspiracy/Coders @Robotic-Conspiracy/Mentors


### PR DESCRIPTION
Adding @Robotic-Conspiracy/Mentors to CODEOWNERS to close #38. This should allow any member of Coders or Mentors to approve PR's to master.